### PR TITLE
fix the  error while trying to run a Python script that requires the …

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ jsonschema==4.22.0
 boto3>=1.28.57
 google-auth<3,>=2
 python-dotenv>=1.0.0
+opencv-python=4.10.0.84


### PR DESCRIPTION
<img width="651" alt="image" src="https://github.com/user-attachments/assets/2819ab7b-fc8a-420b-a71e-5024576fc970">

this error happened on both in windows 11 and windows 10