### PR TITLE
Fixed a typo in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ jsonschema==4.22.0
 boto3>=1.28.57
 google-auth<3,>=2
 python-dotenv>=1.0.0
-opencv-python=4.10.0.84
+opencv-python==4.10.0.84


### PR DESCRIPTION
Fixed a typo in requirements.txt that were causing pip install to throw errors.